### PR TITLE
fix typo

### DIFF
--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -79,7 +79,7 @@ export const questions = [
       {
         value: 1,
         text:
-          "My don't remember my laptop screen background, surely is the default."
+          "I don't remember my laptop screen background, surely is the default."
       }
     ]
   },


### PR DESCRIPTION
Just a small fix in the `Preferred Style` question.

![image](https://user-images.githubusercontent.com/15791418/61277794-d8ecdc00-a7ed-11e9-8157-78338771a193.png)
